### PR TITLE
Update BaseHtml.php

### DIFF
--- a/framework/helpers/BaseHtml.php
+++ b/framework/helpers/BaseHtml.php
@@ -1837,7 +1837,7 @@ class BaseHtml
             throw new InvalidParamException('Attribute name must contain word characters only.');
         }
         $attribute = $matches[2];
-        $value = $model->$attribute;
+        $value = ArrayHelper::getValue($model, $attribute);
         if ($matches[3] !== '') {
             foreach (explode('][', trim($matches[3], '[]')) as $id) {
                 if ((is_array($value) || $value instanceof \ArrayAccess) && isset($value[$id])) {


### PR DESCRIPTION
it pr allow use ar in model as virtual attribute:
example:
```php
class User extend \yii\base\Model
{
    public function __construct($config = [])
    {
        $this->_model = new User();
        parent::__construct($config);
    }
    public function getAr()
    {
        return $this->_model;
    }
}
```
```php
<?= $form->field($model, 'ar.status') ?>
```

now it throw 
```log
Unknown Property – yii\base\UnknownPropertyException
Getting unknown property: app\models\User::ar.status
```

it pr fix it